### PR TITLE
Change for issue: Read Audience Uris from web.config/system.IdentityModel. #246

### DIFF
--- a/Kentor.AuthServices.Tests/Saml2P/Saml2PSecurityTokenHandlerTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2P/Saml2PSecurityTokenHandlerTests.cs
@@ -6,6 +6,9 @@ using Kentor.AuthServices.Configuration;
 
 namespace Kentor.AuthServices.Tests.Saml2P
 {
+    using System.IdentityModel.Tokens;
+    using System.Linq;
+
     [TestClass]
     public class Saml2PSecurityTokenHandlerTests
     {
@@ -15,6 +18,33 @@ namespace Kentor.AuthServices.Tests.Saml2P
             Action a = () => new Saml2PSecurityTokenHandler(null);
 
             a.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("spOptions");
+        }
+
+        [TestMethod]
+        public void Saml2PSecurityTokenHandler_ShouldHaveDefaultAudienceRestrictionOfEntityId()
+        {
+            var spOptions = StubFactory.CreateSPOptions();
+            spOptions.EntityId.Id = "http://testuri/";
+
+            var subject = new Saml2PSecurityTokenHandler(spOptions);
+
+            subject.Configuration.AudienceRestriction.AllowedAudienceUris.First().AbsoluteUri.Should().Be("http://testuri/");
+        }
+
+        [TestMethod]
+        public void Saml2PSecurityTokenHandler_ShouldReadAudienceUrisFromIdentityModelConfig()
+        {
+            var spOptions = StubFactory.CreateSPOptions();
+            spOptions.SystemIdentityModelIdentityConfiguration.AudienceRestriction = 
+                new AudienceRestriction
+                    {
+                        AllowedAudienceUris = { new Uri("http://firsturi/"), new Uri("http://seconduri/") }
+                    };
+
+            var subject = new Saml2PSecurityTokenHandler(spOptions);
+
+            subject.Configuration.AudienceRestriction.AllowedAudienceUris.Should().Contain(new Uri("http://firsturi/"));
+            subject.Configuration.AudienceRestriction.AllowedAudienceUris.Should().Contain(new Uri("http://seconduri/"));
         }
 
         [TestMethod]


### PR DESCRIPTION
Update to constructor on Saml2PSecurityTokenHandler to read audience restrictions from system.identitymodel and fall back to a restriction based on entityid.id if none have been applied. Covered by two tests in Saml2PSecurityTokenHandlerTests: 

Saml2PSecurityTokenHandler_ShouldHaveDefaultAudienceRestrictionOfEntityId
Saml2PSecurityTokenHandler_ShouldReadAudienceUrisFromIdentityModelConfig